### PR TITLE
clock_gettime introduces a dependency on -lrt

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -8,9 +8,9 @@ let () =
     match d with
     | After_rules ->
         flag ["link"; "library"; "ocaml"; "byte"; "use_mtime"]
-          (S [A "-dllib"; A "-lmtime_stubs";]);
+          (S [A "-dllib"; A "-lmtime_stubs"; A "-dllib"; A "-lrt";]);
         flag ["link"; "library"; "ocaml"; "native"; "use_mtime"]
-          (S [A "-cclib"; A "-lmtime_stubs";]);
+          (S [A "-cclib"; A "-lmtime_stubs"; A "-cclib"; A "-lrt";]);
         flag ["link"; "ocaml"; "link_mtime"]
           (A "src-os/libmtime_stubs.a");
         dep ["link"; "ocaml"; "use_mtime"]


### PR DESCRIPTION
Without this patch I hit link errors compiling clients on travis e.g.

  In function `ocaml_mtime_elapsed_ns':
  mtime_stubs.c:(.text+0x26): undefined reference to`clock_gettime'
  mtime_stubs.c:(.text+0x47): undefined reference to `clock_gettime'
  collect2: ld returned 1 exit status
  File "caml_startup", line 1:
  Error: Error during linking
  Command exited with code 2.

I needed this on travis (running Ubuntu) and on my CentOS 7 box. It might be a Linux-ism? It seemed to compile ok for me on OS X though.
