### PR TITLE
Add Mtime.absolute for log correlation use cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ CLOCK.org
 *.native
 *.byte
 *.install
+test_jsoo.*

--- a/src-jsoo/mtime.ml
+++ b/src-jsoo/mtime.ml
@@ -75,6 +75,35 @@ let to_year ms = ms *. ms_to_year
 
 let pp_span ppf ms = pp_span_s ppf (to_s ms)
 
+(* System time *)
+module System = struct
+  type t = float (* milliseconds *)
+
+  let now () = now_ms ()
+
+  let equal = equal
+
+  let compare = compare
+
+  let is_earlier t ~than = compare t than < 0
+
+  let is_later t ~than = compare t than > 0
+
+  let span t t' = abs_float (t -. t')
+
+  (* TODO: detect overflow *)
+  let add_span t s = Some (t +. s)
+
+  (* TODO: detect underflow *)
+  let sub_span t s = Some (t -. s)
+
+  let to_ns_uint64 = to_ns_uint64
+
+  let of_ns_uint64 = of_ns_uint64
+
+  let pp = pp_span
+end
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2015 Daniel C. Bünzli
 

--- a/src-jsoo/mtime.ml
+++ b/src-jsoo/mtime.ml
@@ -32,6 +32,10 @@ let start_ms = now_ms ()
 
 let elapsed () = now_ms () -. start_ms
 
+(* Absolute time *)
+
+let absolute () = now_ms ()
+
 (* Counters *)
 
 type counter = span

--- a/src-os/mtime.ml
+++ b/src-os/mtime.ml
@@ -27,8 +27,14 @@ let count c = Int64.sub (elapsed ()) c
 (* Comparisons *)
 
 let equal = Int64.equal
-(* TODO: unsigned *)
-let compare = Int64.compare
+let compare t t' =
+  if Int64.compare t 0_L < 0
+  then if Int64.compare t' 0_L < 0
+    then Int64.compare t t'
+    else 1
+  else if Int64.compare t' 0_L < 0
+  then -1
+  else Int64.compare t t'
 
 (* Time scale conversion and pretty printers *)
 
@@ -64,13 +70,10 @@ module System = struct
 
   let equal = Int64.equal
 
-  (* TODO: unsigned *)
-  let compare = Int64.compare
+  let compare = compare
 
-  (* TODO: unsigned *)
   let is_earlier t ~than = compare t than < 0
 
-  (* TODO: unsigned *)
   let is_later t ~than = compare t than > 0
 
   (* TODO: unsigned *)

--- a/src-os/mtime.ml
+++ b/src-os/mtime.ml
@@ -76,8 +76,10 @@ module System = struct
 
   let is_later t ~than = compare t than > 0
 
-  (* TODO: unsigned *)
-  let span t t' = Int64.(abs (sub t t'))
+  let span t t' =
+    if compare t t' < 0
+    then Int64.sub t' t
+    else Int64.sub t t'
 
   let add_span t s =
     let sum = Int64.add t s in

--- a/src-os/mtime.ml
+++ b/src-os/mtime.ml
@@ -79,11 +79,16 @@ module System = struct
   (* TODO: unsigned *)
   let span t t' = Int64.(abs (sub t t'))
 
-  (* TODO: detect overflow *)
-  let add_span t s = Some (Int64.add t s)
+  let add_span t s =
+    let sum = Int64.add t s in
+    if compare t sum <= 0
+    then Some sum
+    else None
 
-  (* TODO: detect underflow *)
-  let sub_span t s = Some (Int64.sub t s)
+  let sub_span t s =
+    if compare t s < 0
+    then None
+    else Some (Int64.sub t s)
 
   let to_ns_uint64 ns = ns
 

--- a/src-os/mtime.ml
+++ b/src-os/mtime.ml
@@ -18,6 +18,10 @@ type span = t
 external elapsed : unit -> span = "ocaml_mtime_elapsed_ns"
 let available = elapsed () <> 0L
 
+(* Absolute time *)
+
+external absolute : unit -> span = "ocaml_mtime_absolute_ns"
+
 (* Counters *)
 
 type counter = span

--- a/src-os/mtime.ml
+++ b/src-os/mtime.ml
@@ -27,14 +27,7 @@ let count c = Int64.sub (elapsed ()) c
 (* Comparisons *)
 
 let equal = Int64.equal
-let compare t t' =
-  if Int64.compare t 0_L < 0
-  then if Int64.compare t' 0_L < 0
-    then Int64.compare t t'
-    else 1
-  else if Int64.compare t' 0_L < 0
-  then -1
-  else Int64.compare t t'
+external compare : int64 -> int64 -> int = "ocaml_mtime_uint64_compare"
 
 (* Time scale conversion and pretty printers *)
 

--- a/src-os/mtime.ml
+++ b/src-os/mtime.ml
@@ -18,10 +18,6 @@ type span = t
 external elapsed : unit -> span = "ocaml_mtime_elapsed_ns"
 let available = elapsed () <> 0L
 
-(* Absolute time *)
-
-external absolute : unit -> span = "ocaml_mtime_absolute_ns"
-
 (* Counters *)
 
 type counter = span
@@ -31,6 +27,7 @@ let count c = Int64.sub (elapsed ()) c
 (* Comparisons *)
 
 let equal = Int64.equal
+(* TODO: unsigned *)
 let compare = Int64.compare
 
 (* Time scale conversion and pretty printers *)
@@ -58,6 +55,39 @@ let ns_to_year = ns_to_s *. s_to_year
 let to_year ns = (Int64.to_float ns) *. ns_to_year
 
 let pp_span ppf ns = pp_span_s ppf (to_s ns)
+
+(* System time *)
+module System = struct
+  type t = int64
+
+  external now : unit -> span = "ocaml_mtime_system_now_ns"
+
+  let equal = Int64.equal
+
+  (* TODO: unsigned *)
+  let compare = Int64.compare
+
+  (* TODO: unsigned *)
+  let is_earlier t ~than = compare t than < 0
+
+  (* TODO: unsigned *)
+  let is_later t ~than = compare t than > 0
+
+  (* TODO: unsigned *)
+  let span t t' = Int64.(abs (sub t t'))
+
+  (* TODO: detect overflow *)
+  let add_span t s = Some (Int64.add t s)
+
+  (* TODO: detect underflow *)
+  let sub_span t s = Some (Int64.sub t s)
+
+  let to_ns_uint64 ns = ns
+
+  let of_ns_uint64 ns = ns
+
+  let pp = pp_span
+end
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2015 Daniel C. Bünzli

--- a/src-os/mtime.mli
+++ b/src-os/mtime.mli
@@ -43,6 +43,13 @@ val elapsed : unit -> span
 (** [elapsed ()] is the wall-clock time span elapsed since the
     beginning of the program. *)
 
+(** {1 Absolute time} *)
+
+val absolute : unit -> span
+(** [absolute ()] is the wall-clock time span elapsed since a
+    system-global initialization moment. This value is suitable for
+    multi-process log correlation. *)
+
 (** {1 Time counters} *)
 
 type counter

--- a/src-os/mtime_stubs.c
+++ b/src-os/mtime_stubs.c
@@ -20,6 +20,20 @@
  #endif
 #endif
 
+/* Unsigned int64 comparison */
+CAMLprim value ocaml_mtime_uint64_compare (value x, value y)
+{
+  CAMLparam2 (x, y);
+  int r;
+  uint64_t ux = Int64_val(x), uy = Int64_val(y);
+
+  if (ux < uy) r = -1;
+  else if (ux > uy) r = 1;
+  else r = 0;
+
+  CAMLreturn (Val_int(r));
+}
+
 /* Darwin */
 
 #if defined(OCAML_MTIME_DARWIN)

--- a/src-os/mtime_stubs.c
+++ b/src-os/mtime_stubs.c
@@ -44,7 +44,7 @@ CAMLprim value ocaml_mtime_elapsed_ns (value unit)
 }
 
 // scale is initialized by ocaml_mtime_elapsed_ns during startup
-CAMLprim value ocaml_mtime_absolute_ns (value unit)
+CAMLprim value ocaml_mtime_system_now_ns (value unit)
 {
   uint64_t now = mach_absolute_time ();
   return caml_copy_int64 ((now * scale.numer) / scale.denom);
@@ -71,7 +71,7 @@ CAMLprim value ocaml_mtime_elapsed_ns (value unit)
                           (uint64_t)(now.tv_nsec - start.tv_nsec));
 }
 
-CAMLprim value ocaml_mtime_absolute_ns (value unit)
+CAMLprim value ocaml_mtime_system_now_ns (value unit)
 {
   struct timespec now;
   if (clock_gettime (CLOCK_MONOTONIC, &now)) return caml_copy_int64 (0L);
@@ -92,7 +92,7 @@ CAMLprim value ocaml_mtime_elapsed_ns (value unit)
   return caml_copy_int64 (0L);
 }
 
-CAMLprim value ocaml_mtime_absolute_ns (value unit)
+CAMLprim value ocaml_mtime_system_now_ns (value unit)
 {
   return caml_copy_int64 (0L);
 }

--- a/test-os/tests.ml
+++ b/test-os/tests.ml
@@ -197,12 +197,20 @@ let test_elapsed () =
     (Mtime.to_ns_uint64 span) (Mtime.to_s span) Mtime.pp_span span;
   ()
 
+let test_absolute () =
+  log "Test Mtime.absolute_{s,ns}";
+  let span = Mtime.absolute () in
+  log " * Absolute: %Luns %gs %a"
+    (Mtime.to_ns_uint64 span) (Mtime.to_s span) Mtime.pp_span span;
+  ()
+
 let run () =
   test test_available ();
   test test_secs_in ();
   test test_pp_span_s ();
   test test_counters ();
   test test_elapsed ();
+  test test_absolute ();
   log_result ();
   exit !fail
 

--- a/test-os/tests.ml
+++ b/test-os/tests.ml
@@ -197,11 +197,12 @@ let test_elapsed () =
     (Mtime.to_ns_uint64 span) (Mtime.to_s span) Mtime.pp_span span;
   ()
 
-let test_absolute () =
-  log "Test Mtime.absolute_{s,ns}";
-  let span = Mtime.absolute () in
-  log " * Absolute: %Luns %gs %a"
-    (Mtime.to_ns_uint64 span) (Mtime.to_s span) Mtime.pp_span span;
+let test_system_now () =
+  log "Test Mtime.System.now_{s,ns}";
+  let t = Mtime.System.now () in
+  let span = Mtime.System.(span t (of_ns_uint64 0_L)) in
+  log " * System: %Luns %gs %a"
+    (Mtime.System.to_ns_uint64 t) (Mtime.to_s span) Mtime.System.pp t;
   ()
 
 let run () =
@@ -210,7 +211,7 @@ let run () =
   test test_pp_span_s ();
   test test_counters ();
   test test_elapsed ();
-  test test_absolute ();
+  test test_system_now ();
   log_result ();
   exit !fail
 

--- a/test-os/tests.ml
+++ b/test-os/tests.ml
@@ -205,6 +205,20 @@ let test_system_now () =
     (Mtime.System.to_ns_uint64 t) (Mtime.to_s span) Mtime.System.pp t;
   ()
 
+let test_comparisons () =
+  log "Test Mtime.compare";
+  let zero_mtime = Mtime.of_ns_uint64 0_L in
+  let large_mtime = Mtime.of_ns_uint64 Int64.max_int in
+  let larger_mtime = Mtime.of_ns_uint64 Int64.min_int in
+  let max_mtime = Mtime.of_ns_uint64 (-1_L) in
+  let (<) x y = Mtime.compare x y < 0 in
+  assert (zero_mtime < large_mtime);
+  assert (zero_mtime < larger_mtime);
+  assert (zero_mtime < max_mtime);
+  assert (large_mtime < larger_mtime);
+  assert (large_mtime < max_mtime);
+  assert (larger_mtime < max_mtime)
+
 let run () =
   test test_available ();
   test test_secs_in ();
@@ -212,6 +226,7 @@ let run () =
   test test_counters ();
   test test_elapsed ();
   test test_system_now ();
+  test test_comparisons ();
   log_result ();
   exit !fail
 


### PR DESCRIPTION
This patch adds `Mtime.absolute` which allows processes (or scripts) to share a global reference moment. This, in turn, makes the library usable for log or other timeline correlation between non-cooperating actors.

Please, let me know if there are additional tasks to be done or if you'd like this feature designed differently.
