### PR TITLE
Fixed byte code building of the .cma

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -32,7 +32,7 @@ let () =
         ["link"; "ocaml"; "link_mtime_os_stubs"] (P "src-os/libmtime_stubs.a");
 
       flag ["library"; "ocaml"; "byte"; "record_mtime_os_stubs"]
-        (S ([A "-dllib"; A "-lmtime_stubs"] @ system_support_lib));
+        (S ([A "-cclib"; A "-lmtime_stubs"] @ [A "-dllib"; A "dllmtime_stubs.so"] @ system_support_lib));
       flag ["library"; "ocaml"; (* byte and native *)  "record_mtime_os_stubs"]
         (S ([A "-cclib"; A "-lmtime_stubs"] @ system_support_lib));
 


### PR DESCRIPTION
Without this change the final stage of linking with certain packages (ie. fftw3) resulted in a linker error due to missing symbol ocaml_mtime_elapsed_ns.

My actual case was a bit more complicated: a depending library depended on mtime, and then my application code depended also on fftw3 and then it became impossible to link the resulting byte code binary; native code worked fine. It seems when I introduced fftw3 the final stage of linking was done with cc instead of ocamlc, which resulted in the problem.

I don't claim to understand OCaml library building, but without this change the output of ocamlobjinfo mtime.cma differed from many other OCaml libraries with native code :).

There is a bit redundancy in the original fragment, so you may choose to implement this fix completely separately from this PR as well :).
