### PR TITLE
Fix pattern match against Js.t value

### DIFF
--- a/src-jsoo/mtime_clock.ml
+++ b/src-jsoo/mtime_clock.ml
@@ -16,9 +16,10 @@ let performance_now_ms =
   match Js.Optdef.to_option has_perf with
   | None -> performance_now_ms_unavailable
   | Some p ->
-      match Js.Unsafe.get p "now" with
-      | None -> performance_now_ms_unavailable
-      | Some n -> fun () -> Js.Unsafe.meth_call p "now" [||]
+      if Js.Optdef.test (Js.Unsafe.get p "now") then
+        fun () -> Js.Unsafe.meth_call p "now" [||]
+      else
+        performance_now_ms_unavailable
 
 (* Conversion of DOMHighResTimeStamp to uint64 nanosecond timestamps.
 


### PR DESCRIPTION
Previously the code was interpreting `Js.Unsafe.get p "now"` as an `option`, while it is actually a JavaScript value. This was only working coincidentally due to jsoo's representation of `option` values.