### PR TITLE
Node.js support

### DIFF
--- a/src-jsoo/mtime_clock.ml
+++ b/src-jsoo/mtime_clock.ml
@@ -16,9 +16,10 @@ let performance_now_ms =
   match Js.Optdef.to_option has_perf with
   | None -> performance_now_ms_unavailable
   | Some p ->
-      match Js.Unsafe.get p "now" with
-      | None -> performance_now_ms_unavailable
-      | Some n -> fun () -> Js.Unsafe.meth_call p "now" [||]
+      if Js.Optdef.test (Js.Unsafe.get p "now") then
+        fun () -> Js.Unsafe.meth_call p "now" [||]
+      else
+        performance_now_ms_unavailable
 
 (* Conversion of DOMHighResTimeStamp to uint64 nanosecond timestamps.
 

--- a/src/mtime_clock.mli
+++ b/src/mtime_clock.mli
@@ -99,7 +99,11 @@ val period_ns : unit -> int64 option
        which returns a
        {{:http://www.w3.org/TR/hr-time/#sec-DOMHighResTimeStamp}double
        floating point value} in milliseconds with
-       resolution up to the microsecond.}}
+       resolution up to the microsecond.}
+    {- JavaScript running on Node.js uses the built-in
+       {{:https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_now}[perf_hooks]}
+       module, which provides an interface compatible to the [performance]
+       module in browsers.}}
 *)
 
 


### PR DESCRIPTION
This adds support for Node.js (building on top of #31). It uses [`performance.now`](https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_now) from the experimental [`perf_hooks`](https://nodejs.org/api/perf_hooks.html) module.