### PR TITLE
Fix js_of_ocaml 3.4.0 support

### DIFF
--- a/opam
+++ b/opam
@@ -1,21 +1,37 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: [ "Daniel Bünzli <daniel.buenzl i@erratique.ch>" ]
 homepage: "http://erratique.ch/software/mtime"
 doc: "http://erratique.ch/software/mtime"
-dev-repo: "http://erratique.ch/repos/mtime.git"
+dev-repo: "git+http://erratique.ch/repos/mtime.git"
 bug-reports: "https://github.com/dbuenzli/mtime/issues"
 tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "ISC"
-available: [ ocaml-version >= "4.03.0"]
-depends:
-[
+depends: [
+  "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
 ]
+conflicts: [
+  "js_of_ocaml" {< "2.8.4"} ]
 depopts: [ "js_of_ocaml" ]
 build: [[
    "ocaml" "pkg/pkg.ml" "build"
    "--pinned" "%{pinned}%"
    "--with-js_of_ocaml" "%{js_of_ocaml:installed}%" ]]
+synopsis: "Monotonic wall-clock time for OCaml"
+description: """
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library.
+The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
+and its libraries are distributed under the ISC license.
+
+[jsoo]: http://ocsigen.org/js_of_ocaml/"""

--- a/src-jsoo/mtime_clock.ml
+++ b/src-jsoo/mtime_clock.ml
@@ -4,6 +4,9 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
+module Js = Js_of_ocaml.Js
+module Dom_html = Js_of_ocaml.Dom_html
+
 let us_to_ns = 1000L (* microsecond to nanosecond uint64 multiplier *)
 
 (* Get a handle on JavaScript's performance.now *)


### PR DESCRIPTION
restores compatibility with js_of_ocaml 3.4.0, which removed its non-namespaced API. the `Js_of_ocaml` namespace was added in 2.8.4, so this is no longer compatible with versions before that.

the `opam` file needs a `conflicts` field, but it also needs to be synced with the one in opam-repository first.