### PR TITLE
fix docstring for elapsed_ns

### DIFF
--- a/src/mtime_clock.mli
+++ b/src/mtime_clock.mli
@@ -57,7 +57,7 @@ val count : counter -> Mtime.span
 (** {1:raw Monotonic clock raw interface} *)
 
 val elapsed_ns : unit -> int64
-(** [now_ns ()] is the {e unsigned} 64-bit integer nanosecond monotonic
+(** [elapsed_ns ()] is the {e unsigned} 64-bit integer nanosecond monotonic
      time span elapsed since the beginning of the program.
 
     @raise Sys_error see {{!err}error handling} *)


### PR DESCRIPTION
thanks for this library. In the documentation, the function name is wrongly `now_ns` where it should be `elapsed_ns`.