### PR TITLE
Windows MSVC build support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Allow compiling with MSVC compiler. Jonah Beckford
+
 v1.3.0 2021-10-20 Zagreb
 ------------------------
 

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -38,7 +38,7 @@ let () =
 
       (* mtime-clock-os *)
 
-      dep ["record_mtime_clock_os_stubs"] ["src-os/libmtime_clock_stubs.a"];
+      dep ["record_mtime_clock_os_stubs"] [lib "src-os/libmtime_clock_stubs"];
       flag_and_dep
         ["link"; "ocaml"; "link_mtime_clock_os_stubs"]
         (P (lib "src-os/libmtime_clock_stubs"));


### PR DESCRIPTION
The original code was looking for `src-os/libmtime_clock_stubs.a`. But the MSVC compiler needs `src-os/libmtime_clock_stubs.lib`.

This PR is similar to https://github.com/dbuenzli/ptime/pull/23