### PR TITLE
Add `is_shorter` and `is_longer` to spans

### DIFF
--- a/src/mtime.ml
+++ b/src/mtime.ml
@@ -22,6 +22,8 @@ module Span = struct
 
   let equal = Int64.equal
   let compare = Int64.unsigned_compare
+  let is_shorter s ~than = compare s than < 0
+  let is_longer s ~than = compare s than > 0
 
   (* Arithmetic *)
 

--- a/src/mtime.mli
+++ b/src/mtime.mli
@@ -55,6 +55,12 @@ module Span : sig
   val compare : span -> span -> int
   (** [compare span span'] orders spans by increasing duration. *)
 
+  val is_shorter : span -> than:span -> bool
+  (** [is_shorter span ~than] is [true] iff [span] lasts less than [than]. *)
+
+  val is_longer : span -> than:span -> bool
+  (** [is_longer span ~than] is [true] iff [span] lasts more than [than]. *)
+
   (** {1:arith Arithmetic} *)
 
   val add : span -> span -> span

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -290,21 +290,20 @@ let test_span_compare () =
   let large_mtime = Mtime.Span.of_uint64_ns Int64.max_int in
   let larger_mtime = Mtime.Span.of_uint64_ns Int64.min_int in
   let max_mtime = Mtime.Span.of_uint64_ns (-1_L) in
-  let (<) x y = Mtime.Span.compare x y < 0 in
-  assert (zero_mtime < large_mtime);
-  assert (zero_mtime < larger_mtime);
-  assert (zero_mtime < max_mtime);
-  assert (large_mtime < larger_mtime);
-  assert (large_mtime < max_mtime);
-  assert (larger_mtime < max_mtime);
-  let (<) x y = Mtime.Span.compare y x > 0 in
-  assert (zero_mtime < large_mtime);
-  assert (zero_mtime < large_mtime);
-  assert (zero_mtime < larger_mtime);
-  assert (zero_mtime < max_mtime);
-  assert (large_mtime < larger_mtime);
-  assert (large_mtime < max_mtime);
-  assert (larger_mtime < max_mtime);
+  let test_less_than fn =
+    let (<) = fn in
+    assert (zero_mtime < large_mtime);
+    assert (zero_mtime < larger_mtime);
+    assert (zero_mtime < max_mtime);
+    assert (large_mtime < larger_mtime);
+    assert (large_mtime < max_mtime);
+    assert (larger_mtime < max_mtime);
+    ()
+  in
+  test_less_than (fun x y -> Mtime.Span.compare x y < 0);
+  test_less_than (fun x y -> Mtime.Span.is_shorter x ~than:y);
+  test_less_than (fun x y -> Mtime.Span.compare y x > 0);
+  test_less_than (fun x y -> Mtime.Span.is_longer y ~than:x);
   ()
 
 let test_span_constants () =


### PR DESCRIPTION
While changing quite a bit of "wait until timout" situations from floats into mtime, I've received comments about the compare not being obvious, probably because of the unfamiliarity with spans.

I think these two analogous functions to `is_earlier` and `is_later` for spans will make the comparisons obvious even to unfamiliar users.