### PR TITLE
Minor follow-up for macOS mach time fix

### DIFF
--- a/src/clock/mtime_clock_stubs.c
+++ b/src/clock/mtime_clock_stubs.c
@@ -59,7 +59,7 @@ CAMLprim value ocaml_mtime_clock_elapsed_ns (value unit)
   static uint64_t start = 0L;
   if (start == 0L) { start = ocaml_darwin_mach_time (); }
   if (scale.denom == 0) { ocaml_mtime_clock_init_scale (); }
-  uint64_t now = mach_continuous_time ();
+  uint64_t now = ocaml_darwin_mach_time ();
   return caml_copy_int64 (((now - start) * scale.numer) / scale.denom);
 }
 

--- a/src/clock/mtime_clock_stubs.c
+++ b/src/clock/mtime_clock_stubs.c
@@ -36,8 +36,9 @@
 #if defined(OCAML_MTIME_DARWIN)
 
 #include <mach/mach_time.h>
+#include <AvailabilityMacros.h>
 
-#if __MACOSX_VERSION_MIN_REQUIRED >= 101200
+#if MACOSX_VERSION_MIN_REQUIRED >= 101200
   #define ocaml_darwin_mach_time mach_continuous_time
 #else
   #define ocaml_darwin_mach_time mach_absolute_time


### PR DESCRIPTION
@dbuenzli Sorry for a delay, there is one instance which was missed last time. Also it is preferable to use macros without underscores, since those are defined in specific public header, and work on all macOS versions.